### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ This method is demonstrated in the included example project (example/FileDroneEx
 
 5. Build your project (⌘B). All going well, you should get a 'Build Succeeded' notification. This signifies that you're ready to implement FileDrone in your project.
 
-###Cocoapods
+###CocoaPods
 
-FileDrone can be installed *very* easily if you use [Cocoapods](http://cocoapods.org) with your projects. The podspec is included in the Github repository, and is also available through [cocoapods.org](http://cocoapods.org/?q=FileDrone).
+FileDrone can be installed *very* easily if you use [CocoaPods](http://cocoapods.org) with your projects. The podspec is included in the Github repository, and is also available through [cocoapods.org](http://cocoapods.org/?q=FileDrone).
 
 Simply add the project to your `Podfile` by adding the line:
 
@@ -38,7 +38,7 @@ You can also specify a version to include, such as 0.1.0:
 pod 'FileDrone', '0.1.0'
 ```
 
-For more information on how to add projects using Cocoapods, read [their documentation on Podfiles](http://docs.cocoapods.org/podfile.html).
+For more information on how to add projects using CocoaPods, read [their documentation on Podfiles](http://docs.cocoapods.org/podfile.html).
 
 ##Implementing FileDrone
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
